### PR TITLE
Change API URLs in README from HTTP to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ La documentación de la API fue generada utilizando NelmioApiDocBundle, que perm
 Puedes acceder a la especificación de la API de las siguientes maneras:
 
 - UI interactiva (Swagger):
-    - http://localhost/api/doc
+    - https://localhost/api/doc
 
 - Documento JSON OpenAPI:
-    - http://localhost/api/doc.json
+    - https://localhost/api/doc.json
 
 ## Modelado del Dominio
 El dominio está diseñado bajo los principios de DDD y Arquitectura Hexagonal, incluyendo:


### PR DESCRIPTION
Since the Docker environment has been configured to use HTTPS for enhanced security, the project documentation has been updated to reflect this change by replacing the backend URLs in the README file from http to https
